### PR TITLE
Changed Laravel requirement to 4.x and added a branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
             "Sidney\\Latchet": "src/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
I'm currently using my own fork of Latchet (in which I made these two small changes to the composer.json) in my project and Latchet seems to be working fine with Laravel 4.1.18.    
