### PR TITLE
Fix connection close removeSubscriber logic bug.

### DIFF
--- a/src/Sidney/Latchet/Latchet.php
+++ b/src/Sidney/Latchet/Latchet.php
@@ -345,7 +345,7 @@ class Latchet implements WampServerInterface {
 		if ($this->enablePush)
 	        {
 	            // After connection is closed, the subscriber topic must be reset	
-	            $this->pusher->removeSubscriber();
+	            $this->pusher->removeSubscriber($connection);
 	        }
 
 		$this->dispatch('close', compact('connection'));


### PR DESCRIPTION
hi @sidneywidmer. I have fixed a serious bug of Latchet.

The fact is:

step1. A client named `A` connection to server first and subscribe a topic named `conversation_to_a`

step2. then the client `B` connected to server and subscribe a topic named `conversation_to_b`.

step3. Now, A send a mesage to B, server publish a message to `conversation_to_a` and `conversation_to_b`. A and B will received the message.

step4. when A or B disconnect and reconnect again(for example A). the same things as step 1,2,3
When A send a mesage to B, B can't received the message. But A can received B's.

I reviewed the code in file Latchet.php. I found that 

``` php
public function onClose(Conn $connection)
  {
    if ($this->enablePush) {
      // After connection is closed, the subscriber topic must be reset
      $this->pusher->removeSubscriber(); // !!! this statement will make all subscribers empty.

    }
    $this->dispatch('close', compact('connection'));
  }
```

The statement `$this->subscribedTopics = array()` is where the bug is.

That is why when A send a mesage to B, B can't received the message. But A can received B's after A reconnect. 

A reconnect will `re-subscribe` the topic `conversation_to_a`, so A can receive B's.
**BUT B IS NOT RECONNECT** that there is only one subscriber  `conversation_to_a` in `$this->subscribedTopics` . So when A send to B, server publish can not resolve a subscriber for `conversation_to_b`, and B can not received A's
